### PR TITLE
pr

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -21,6 +21,19 @@
 #include <kernel/thread.h>
 #include <lk/debug.h>
 #include <lk/err.h>
+#include <lk/init.h>
+
+static bool mutex_threading_ready;
+
+/* mutex_threading_ready is currently only used from a DEBUG_ASSERT */
+#if LK_DEBUGLEVEL > 1
+
+static void mutex_threading_ready_init_func(uint level) {
+    mutex_threading_ready = true;
+}
+
+LK_INIT_HOOK(mutex_threading_ready, mutex_threading_ready_init_func, LK_INIT_LEVEL_THREADING);
+#endif
 
 /**
  * @brief  Initialize a mutex_t
@@ -69,6 +82,7 @@ status_t mutex_acquire_timeout(mutex_t *m, lk_time_t timeout) {
         panic("mutex_acquire_timeout: thread %p (%s) tried to acquire mutex %p it already owns.\n",
               get_current_thread(), get_current_thread()->name, m);
 #endif
+    DEBUG_ASSERT(!mutex_threading_ready || !timeout || !arch_ints_disabled());
 
     THREAD_LOCK(state);
 


### PR DESCRIPTION
Calling mutex_acquire with interrupts disabled is usually unsafe. Add a debug assert to catch this. Only check this after threading is enabled on the primary CPU though, as the thread that runs the initial init hooks run with interrupts disabled and in this case no other thread can own the mutex anyway. Also allow 0 timeout since
vmm_get_address_description uses this to allow exception handlers to dump additional information when the vmm_lock is available.

Bug: 304850822
Change-Id: I22c91c48b7853c0b8e0eb8da61cdfc9cd1650ae8